### PR TITLE
Allow installation on Laravel 5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": "~7.0",
-        "illuminate/support": "~5.5.0",
+        "illuminate/support": ">=5.5.0",
         "stidges/country-flags": "^1.0.0"
     },
     "require-dev": {


### PR DESCRIPTION
Allow package to be installed on any Laravel version greater than 5.5