### PR TITLE
Support for Laravel 9.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": "^7.3|^8.0",
-        "illuminate/support": "^7.0|^8.0",
+        "illuminate/support": "^7.0|^8.0|^9.0",
         "stidges/country-flags": "^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
Change a dependency so that it would work with Laravel 9. Without this patch, `composer update` will fail with unmet dependency issues.